### PR TITLE
Ensure options are passed to fetch()

### DIFF
--- a/src/L.Realtime.js
+++ b/src/L.Realtime.js
@@ -36,7 +36,7 @@ L.Realtime = L.Layer.extend({
                 }
                 var url = this.options.cache ? url : this._bustCache(url);
 
-                fetch(url)
+                fetch(url, fetchOptions)
                 .then(function(response) {
                     return response.json();
                 })


### PR DESCRIPTION
This PR fixes an issue where arguments are not being passed to fetch(). 

The project Readme states that it is possible to provide arguments to realtime(), but only the URL is being passed to fetch(). It is necessary to be able to supply arguments to fetch so that authentication (e.g. cookies) can be used when making calls to an endpoint that requires a valid user session. 

If I've overlooked something, please let me know!